### PR TITLE
Add missing CNAO's CR manifest and bump kubevirt

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -28,7 +28,7 @@ source ./cluster/cluster.sh
 CNAO_VERSION=v0.76.1
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.56)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.59)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then

--- a/hack/cna/cna-cr.yaml
+++ b/hack/cna/cna-cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
+kind: NetworkAddonsConfig
+metadata:
+  name: cluster
+spec:
+  imagePullPolicy: Always
+  multus: {}


### PR DESCRIPTION
Add missing CNAO's CR manifest, in order to allow deploying CNAO and it's CR.
Bump kubevirt so we can create VMs on k8s-1.25 as well.

```release-note
None
```