### PR TITLE
manifest: Change default values of env vars

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -6,8 +6,8 @@ metadata:
 ---
 apiVersion: v1
 data:
-  DOMAIN: secondary.io
-  NAME_SERVER_IP: 127.0.0.1
+  DOMAIN: ""
+  NAME_SERVER_IP: ""
   Corefile: |
     .:53 {
         auto {

--- a/tests/vm_startup_test.go
+++ b/tests/vm_startup_test.go
@@ -24,7 +24,7 @@ const pollingInterval = 5 * time.Second
 const testNamespacePrefix = "secondary-test"
 const dnsPort = "31111"
 const dnsIP = "127.0.0.1" // Forwarded to the node port - https://github.com/kubevirt/kubevirtci/pull/867
-const domain = "vm.secondary.io"
+const domain = "vm"
 
 var testNamespace string
 


### PR DESCRIPTION
Use empty strings as default values for the env vars. 
The Zone manager will set the defaults accordingly. 
This allows to deploy the manifest as is.

Since CNAO CR also doesn't have values, it will align the e2e test to
work when running from CNAO (using default values).

```release-note
None
```