### PR TITLE
sync: Label the control-plane as worker

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -51,4 +51,5 @@ pods_ready_wait() {
 }
 
 pods_ready_wait
+./cluster/kubectl.sh label node node01 node-role.kubernetes.io/worker=worker
 make create-nodeport


### PR DESCRIPTION
Since the NodePort is created for only workers,
label the control plane node as worker.
So we can use multi nodes if needed.
The dns traffic is forwarded only to the first node by kubevirtci, 
so we need the nodeport to serve also for the first node.

```release-note
None
```