### PR TITLE
[e2e] adding a period to the tested fqdn and improve error readability

### DIFF
--- a/tests/vm_startup_test.go
+++ b/tests/vm_startup_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Virtual Machines Startup", func() {
 			var nslookupOutput []byte
 			Eventually(func() error {
 				var nslookupErr error
-				nslookupOutput, nslookupErr = exec.Command("nslookup", fmt.Sprintf("-port=%s", dnsPort), fmt.Sprintf("%s.%s.%s.%s", interfaceName, vmiName, testNamespace, domain), dnsIP).CombinedOutput()
+				nslookupOutput, nslookupErr = exec.Command("nslookup", fmt.Sprintf("-port=%s", dnsPort), fmt.Sprintf("%s.%s.%s.%s.", interfaceName, vmiName, testNamespace, domain), dnsIP).CombinedOutput()
 				if nslookupErr != nil {
 					nslookupErr = fmt.Errorf("err: %v, output: %s", nslookupErr, nslookupOutput)
 				}

--- a/tests/vm_startup_test.go
+++ b/tests/vm_startup_test.go
@@ -89,8 +89,11 @@ var _ = Describe("Virtual Machines Startup", func() {
 			Eventually(func() error {
 				var nslookupErr error
 				nslookupOutput, nslookupErr = exec.Command("nslookup", fmt.Sprintf("-port=%s", dnsPort), fmt.Sprintf("%s.%s.%s.%s", interfaceName, vmiName, testNamespace, domain), dnsIP).CombinedOutput()
+				if nslookupErr != nil {
+					nslookupErr = fmt.Errorf("err: %v, output: %s", nslookupErr, nslookupOutput)
+				}
 				return nslookupErr
-			}, time.Minute, pollingInterval).ShouldNot(HaveOccurred(), fmt.Sprintf("nslookup failed. Output - %s", nslookupOutput))
+			}, time.Minute, pollingInterval).ShouldNot(HaveOccurred(), "nslookup failed")
 
 			By("Comparing the VirtualMachineInstance IP to the nslookup result")
 			Expect(nslookupOutput).To(ContainSubstring(fmt.Sprintf("Address: %s\n", vmiIp)), fmt.Sprintf("nsloookup doesn't return the VMI IP address - %s. nslookup output - %s", vmiIp, nslookupOutput))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
The PR contains two commits.
The first one is  adding a period to the tested fqdn.
According to the nslokkup man page - 
```
If the lookup request contains at least one period but doesn't end with a trailing period, append the domain names in the domain search list to the request until an answer is received.
To avoid this, a period is added to our fqdn.
```
    
The second one returns readable `nslookup` error.   



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
