### PR TITLE
Handle status monitor container reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	zoneManager := zonemgr.NewZoneManager()
+	zoneManager, err := zonemgr.NewZoneManager()
+	if err != nil {
+		setupLog.Error(err, "unable to create zone manager")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.VirtualMachineInstanceReconciler{
 		Client:      mgr.GetClient(),
 		Log:         ctrl.Log.WithName("controllers").WithName("VirtualMachineInstance"),

--- a/pkg/zonemgr/zone_file.go
+++ b/pkg/zonemgr/zone_file.go
@@ -1,10 +1,16 @@
 package zonemgr
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 )
 
 const zoneFilePerm = 0644
+
+var soaSerialReg = regexp.MustCompile("SOA .*\\(([0-9]+) ")
 
 type ZoneFile struct {
 	zoneFileFullName string
@@ -18,4 +24,43 @@ func NewZoneFile(fileName string) *ZoneFile {
 
 func (zoneFile *ZoneFile) writeFile(content string) (err error) {
 	return os.WriteFile(zoneFile.zoneFileFullName, []byte(content), zoneFilePerm)
+}
+
+func (zoneFile *ZoneFile) readFile() ([]byte, error) {
+	return os.ReadFile(zoneFile.zoneFileFullName)
+}
+
+func (zoneFile *ZoneFile) isFileExist() (bool, error) {
+	var err error
+	isExist := false
+	if _, err = os.Stat(zoneFile.zoneFileFullName); err == nil {
+		isExist = true
+	} else if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	return isExist, err
+}
+
+func (zoneFile *ZoneFile) ReadSoaSerial() (*int, error) {
+	if isFileExist, err := zoneFile.isFileExist(); !isFileExist || err != nil {
+		return nil, err
+	}
+	if content, err := zoneFile.readFile(); content == nil || err != nil {
+		return nil, err
+	} else {
+		return fetchSoaSerial(string(content))
+	}
+}
+
+func fetchSoaSerial(content string) (*int, error) {
+	if result := soaSerialReg.FindStringSubmatch(content); result != nil && len(result) > 0 {
+		soaSerial := result[1]
+		if soaSerialInt, err := strconv.Atoi(soaSerial); err == nil {
+			return &soaSerialInt, nil
+		} else {
+			return nil, err
+		}
+	} else {
+		return nil, errors.New(fmt.Sprintf("failed to fetch SOA serial value from the zone file content: %s", content))
+	}
 }

--- a/pkg/zonemgr/zone_manager_test.go
+++ b/pkg/zonemgr/zone_manager_test.go
@@ -21,7 +21,9 @@ var _ = Describe("Zone Manager functionality", func() {
 	BeforeEach(func() {
 		os.Setenv("DOMAIN", customDomain)
 		os.Setenv("NAME_SERVER_IP", customNSIP)
-		zoneMgr = NewZoneManager()
+		var err error
+		zoneMgr, err = NewZoneManager()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("Initialization", func() {
@@ -40,12 +42,6 @@ var _ = Describe("Zone Manager functionality", func() {
 
 		It("should create zone file with correct name", func() {
 			Expect(zoneMgr.zoneFile.zoneFileFullName).To(Equal("/zones/db.vm." + customDomain))
-		})
-
-		When("zone file already exist", func() {
-			It("should update cached SOA serial value", func() {
-				//TODO
-			})
 		})
 	})
 })


### PR DESCRIPTION
Flow description:

1. When  status monitor container is loaded, it creates a zone file and initializes it with the header and A records. In this case SOA serial initial value will be 1
2. Each time status monitor updates zone file, it increments SOA serial value
3. Auto plugin inside Corefile is responsible to reload zone file newest data into the DNS when it identifies that SOA serial value was changed

PR adds the below logic:

If status monitor container was reloaded, on its startup it should check whether zone file already exist.
If yes, it should continue the existing SOA serial sequence instead of setting it back to 1. 
The reason for that is the below edge case:

- If zone file already exist and holds SOA serial = 1 (for example) and status monitor container was restarted
- Then even after status monitor will override zone file content with the new data, the SOA serial will remain the same (=1)
- Thus it will not be reloaded by the auto plugin since the SOA serial didn't change

**Release note:**

```release-note
NONE
```
