### PR TITLE
Adding missing nameserver name to custom A record

### DIFF
--- a/pkg/zonemgr/zone_file_cache.go
+++ b/pkg/zonemgr/zone_file_cache.go
@@ -79,7 +79,7 @@ func (zoneFileCache *ZoneFileCache) generateHeaderSuffix() {
 
 	if zoneFileCache.nameServerIP != "" {
 		zoneFileCache.headerSuf += fmt.Sprintf("IN NS %s.\n", zoneFileCache.nameServerName)
-		zoneFileCache.headerSuf += fmt.Sprintf("IN A %s\n", zoneFileCache.nameServerIP)
+		zoneFileCache.headerSuf += fmt.Sprintf("%s IN A %s\n", nameServerDefault, zoneFileCache.nameServerIP)
 	}
 }
 

--- a/pkg/zonemgr/zone_file_cache_test.go
+++ b/pkg/zonemgr/zone_file_cache_test.go
@@ -24,7 +24,7 @@ var _ = Describe("cached zone file content maintenance", func() {
 	Describe("cached zone file initialization", func() {
 		const (
 			headerDefault   = "$ORIGIN vm. \n$TTL 3600 \n@ IN SOA ns.vm. email.vm. (0 3600 3600 1209600 3600)\n"
-			headerCustomFmt = "$ORIGIN vm.%s. \n$TTL 3600 \n@ IN SOA ns.vm.%s. email.vm.%s. (0 3600 3600 1209600 3600)\nIN NS ns.vm.%s.\nIN A %s\n"
+			headerCustomFmt = "$ORIGIN vm.%s. \n$TTL 3600 \n@ IN SOA ns.vm.%s. email.vm.%s. (0 3600 3600 1209600 3600)\nIN NS ns.vm.%s.\nns IN A %s\n"
 		)
 
 		var (


### PR DESCRIPTION
In case custom variables are populated, for example:
```
DOMAIN=secondary.io
NAME_SERVER_IP=1.2.3.4
```

Then the zone file should contain the below two records (KubeSecondaryDNS nameserver details as defined in external domain server):
```
IN NS ns.vm.secondary.io.
ns IN A 1.2.3.4
```

This PR adds `ns` prefix inside the A record as shown above.
`ns` is the default KubeSecondaryDNS nameserver name

The two records eventually will be converted by the DNS engine into this:
```
vm.secondary.io. IN NS ns.vm.secondary.io.
ns.vm.secondary.io. IN A 1.2.3.4
```

- NS record has no prefix, therefore `@` that comes in the line before (SOA record) should catch here. And be replaced by `$ORIGIN` value
- A record has `ns` prefix but no `.` at the end therefore should be completed with  $ORIGIN

Signed-off-by: Diana Teplits <dteplits@redhat.com>

```release-note
NONE
```
