### PR TITLE
Make secondary-dns deployment PSA ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 DNS for KubeVirt VirtualMachines secondary interfaces
 
 ## Prerequisites
-1. The KubeSecondaryDNS Deployment should be reachable from outside the cluster.  
+1. The KubeSecondaryDNS Deployment which listens on port 5353 should be reachable from outside the cluster.  
 It can be exposed using NodePort, Load Balancer, Ingress or any other methodology.  
 The IP to reach the KubeSecondaryDNS from outside the cluster would be called from now on  
 "KubeSecondaryDNS public IP".
 2. The secondary interfaces IPs must appear on the VMI status.  
-For this IPs should be either declared statically (i.e with CNI) or to have a guest agent installed.
+For this, IPs should be either declared statically (i.e with CNI) or to have a guest agent installed.
 3. Kubevirt must be installed, else the plugin would have an error.
 4. If necessary, establish connectivity to KubeSecondaryDNS public IP via a relevant DNS entity that is used to
 reach the authoritative KubeSecondaryDNS server, such as DNSResolver, TLD NameServer, etc.

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -14,7 +14,7 @@
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
 export KUBEVIRT_NUM_NODES=1
-export KUBEVIRTCI_TAG='2211212125-021efaa'
+export KUBEVIRTCI_TAG='2212161203-bcbedfe'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,6 +18,7 @@ set -ex pipefail
 
 export DEPLOY_CNAO=${DEPLOY_CNAO:-true}
 export DEPLOY_KUBEVIRT=${DEPLOY_KUBEVIRT:-true}
+export KUBEVIRT_PSA=${KUBEVIRT_PSA:-false}
 
 source ./cluster/cluster.sh
 

--- a/hack/create-nodeport.sh
+++ b/hack/create-nodeport.sh
@@ -13,5 +13,5 @@ if [ -z $NAMESPACE ]; then
   exit 1
 fi
 
-${KUBECTL} expose -n ${NAMESPACE} deployment/secondary-dns --name=dns-nodeport --type=NodePort --port=31111 --target-port=53 --protocol='UDP'
+${KUBECTL} expose -n ${NAMESPACE} deployment/secondary-dns --name=dns-nodeport --type=NodePort --port=31111 --target-port=5353 --protocol='UDP'
 ${KUBECTL} patch -n ${NAMESPACE} service/dns-nodeport --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":31111}]'

--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -9,7 +9,7 @@ data:
   DOMAIN: ""
   NAME_SERVER_IP: ""
   Corefile: |
-    .:53 {
+    .:5353 {
         auto {
           directory /zones db\.(.*) {1}
           reload 45s
@@ -75,6 +75,11 @@ spec:
         kubectl.kubernetes.io/default-container: status-monitor
     spec:
       serviceAccountName: secondary
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
       - args:
         - -conf
@@ -82,8 +87,12 @@ spec:
         image: k8s.gcr.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         name: secondary-dns
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         ports:
-        - containerPort: 53
+        - containerPort: 5353
           name: dns
           protocol: UDP
         resources:
@@ -100,6 +109,10 @@ spec:
           mountPath: /zones
           readOnly: true
       - name: status-monitor
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         image: registry:5000/kubevirt/kubesecondarydns:latest
         volumeMounts:
         - name: secdns-zones


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
Make secondary-dns deployment PSA ready
    
Can be tested by -
`kubectl label --dry-run=server --overwrite ns secondary pod-security.kubernetes.io/enforce=restricted`

Without this PR, those kind of warnings are returned - 
```
Warning: existing pods in namespace "secondary" violate the new PodSecurity enforce level "restricted:latest"
Warning: secondary-dns-6fcbb7cf65-8qfnm: allowPrivilegeEscalation != false, unrestricted capabilities, runAsNonRoot != true, seccompProfile
```
   
https://kubernetes.io/docs/concepts/security/pod-security-admission/


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
 Make secondary-dns deployment PSA ready
```
