### PR TITLE
controller: Move interface_filter to internal package

### DIFF
--- a/pkg/controllers/internal/filter/filter_suite_test.go
+++ b/pkg/controllers/internal/filter/filter_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package filter
 
 import (
 	"testing"
@@ -25,5 +25,5 @@ import (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "Filter Suite")
 }

--- a/pkg/controllers/internal/filter/interface_filter.go
+++ b/pkg/controllers/internal/filter/interface_filter.go
@@ -1,4 +1,4 @@
-package controllers
+package filter
 
 import (
 	v1 "kubevirt.io/api/core/v1"

--- a/pkg/controllers/internal/filter/interface_filter_test.go
+++ b/pkg/controllers/internal/filter/interface_filter_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package filter_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -6,7 +6,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	"github.com/kubevirt/kubesecondarydns/pkg/controllers"
+	"github.com/kubevirt/kubesecondarydns/pkg/controllers/internal/filter"
 )
 
 var _ = Describe("FilterMultusNonDefaultInterfaces", func() {
@@ -15,23 +15,23 @@ var _ = Describe("FilterMultusNonDefaultInterfaces", func() {
 	const nonDefaultName2 = "non default2"
 
 	It("when interfaces and networks lists are nil", func() {
-		Expect(controllers.FilterMultusNonDefaultInterfaces(nil, nil)).To(BeEmpty())
+		Expect(filter.FilterMultusNonDefaultInterfaces(nil, nil)).To(BeEmpty())
 	})
 	It("when interfaces and networks lists are empty", func() {
-		Expect(controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{}, []v1.Network{})).To(BeEmpty())
+		Expect(filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{}, []v1.Network{})).To(BeEmpty())
 	})
 	It("when there is only default network", func() {
-		Expect(controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface(defaultName)}, []v1.Network{createDefaultNetwork(defaultName)})).To(BeEmpty())
+		Expect(filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface(defaultName)}, []v1.Network{createDefaultNetwork(defaultName)})).To(BeEmpty())
 	})
 	It("when there is a non default interface", func() {
 		nonDefaultInterface := createVmInterface(nonDefaultName)
-		result := controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, createVmInterface(defaultName)}, []v1.Network{createDefaultNetwork(defaultName), createMultusNonDefaultNetwork(nonDefaultName)})
+		result := filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, createVmInterface(defaultName)}, []v1.Network{createDefaultNetwork(defaultName), createMultusNonDefaultNetwork(nonDefaultName)})
 		Expect(result).To(ConsistOf(nonDefaultInterface))
 	})
 	It("when there is default network and multiple non default interface", func() {
 		nonDefaultInterface := createVmInterface(nonDefaultName)
 		nonDefaultInterface2 := createVmInterface(nonDefaultName2)
-		result := controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface(defaultName), nonDefaultInterface, nonDefaultInterface2}, []v1.Network{createDefaultNetwork(defaultName)})
+		result := filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface(defaultName), nonDefaultInterface, nonDefaultInterface2}, []v1.Network{createDefaultNetwork(defaultName)})
 		Expect(result).To(ConsistOf(nonDefaultInterface, nonDefaultInterface2))
 	})
 	It("when there is a multus default interface", func() {
@@ -43,30 +43,30 @@ var _ = Describe("FilterMultusNonDefaultInterfaces", func() {
 			Name: defaultName,
 		}
 
-		result := controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, nonDefaultInterface2}, []v1.Network{multusDefaultNetwork, createMultusNonDefaultNetwork(nonDefaultName), createMultusNonDefaultNetwork(nonDefaultName2)})
+		result := filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, nonDefaultInterface2}, []v1.Network{multusDefaultNetwork, createMultusNonDefaultNetwork(nonDefaultName), createMultusNonDefaultNetwork(nonDefaultName2)})
 		Expect(result).To(ConsistOf(nonDefaultInterface, nonDefaultInterface2))
 	})
 	It("when there is no default network", func() {
 		nonDefaultInterface := createVmInterface(nonDefaultName)
 		nonDefaultInterface2 := createVmInterface(nonDefaultName2)
-		result := controllers.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, nonDefaultInterface2}, []v1.Network{createMultusNonDefaultNetwork(nonDefaultName), createMultusNonDefaultNetwork(nonDefaultName2)})
+		result := filter.FilterMultusNonDefaultInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nonDefaultInterface, nonDefaultInterface2}, []v1.Network{createMultusNonDefaultNetwork(nonDefaultName), createMultusNonDefaultNetwork(nonDefaultName2)})
 		Expect(result).To(ConsistOf(nonDefaultInterface, nonDefaultInterface2))
 	})
 })
 
 var _ = Describe("FilterInterfacesWithNoName", func() {
 	It("when interfaces list is nil", func() {
-		Expect(controllers.FilterNamedInterfaces(nil)).To(BeEmpty())
+		Expect(filter.FilterNamedInterfaces(nil)).To(BeEmpty())
 	})
 	It("when interface list is empty", func() {
-		Expect(controllers.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{})).To(BeEmpty())
+		Expect(filter.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{})).To(BeEmpty())
 	})
 	It("when there is one interface without a name", func() {
-		Expect(controllers.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface("")})).To(BeEmpty())
+		Expect(filter.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{createVmInterface("")})).To(BeEmpty())
 	})
 	It("when there is one inteface with a name", func() {
 		iface := createVmInterface("nic1")
-		result := controllers.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{iface})
+		result := filter.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{iface})
 		Expect(result).To(ConsistOf(iface))
 	})
 	It("when there are multiple interface, some with name some without", func() {
@@ -74,7 +74,7 @@ var _ = Describe("FilterInterfacesWithNoName", func() {
 		nic2 := createVmInterface("")
 		nic3 := createVmInterface("nic3")
 		nic4 := createVmInterface("")
-		result := controllers.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nic1, nic2, nic3, nic4})
+		result := filter.FilterNamedInterfaces([]v1.VirtualMachineInstanceNetworkInterface{nic1, nic2, nic3, nic4})
 		Expect(result).To(ConsistOf(nic1, nic3))
 	})
 })

--- a/pkg/controllers/virtualmachineinstance_controller.go
+++ b/pkg/controllers/virtualmachineinstance_controller.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"github.com/kubevirt/kubesecondarydns/pkg/controllers/internal/filter"
 	"github.com/kubevirt/kubesecondarydns/pkg/zonemgr"
 )
 
@@ -54,9 +55,9 @@ func (r *VirtualMachineInstanceReconciler) Reconcile(ctx context.Context, reques
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-	filteredInterfaces := FilterMultusNonDefaultInterfaces(vmi.Status.Interfaces, vmi.Spec.Networks)
+	filteredInterfaces := filter.FilterMultusNonDefaultInterfaces(vmi.Status.Interfaces, vmi.Spec.Networks)
 	// The interface/network name is used to build the FQDN, therefore, interfaces reported without a name are filtered out
-	filteredInterfaces = FilterNamedInterfaces(filteredInterfaces)
+	filteredInterfaces = filter.FilterNamedInterfaces(filteredInterfaces)
 	err = r.ZoneManager.UpdateZone(request.NamespacedName, filteredInterfaces)
 
 	return ctrl.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce the exported methods visibility.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
