### PR TITLE
Updated k8s registry from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -84,7 +84,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         name: secondary-dns
         securityContext:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
This PR is part of the Umbrella issue, https://github.com/kubernetes/k8s.io/issues/4780

**Special notes for your reviewer**:
With the change to defaulting to registry.k8s.io as the image registry and the planned freeze in April, 
downstream projects will likely be impacted, so the image registry needs 
to be updated from k8s.gcr.io to registry.k8s.io.