### PR TITLE
Run kubevirt lane with KUBEVIRT_PSA=true

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -50,5 +50,10 @@ pods_ready_wait() {
   fi
 }
 
+enable_psa_feature_gate() {
+  ./cluster/kubectl.sh apply -f ./hack/psa/kubevirt.yaml
+}
+
 pods_ready_wait
 make create-nodeport
+enable_psa_feature_gate

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,7 +18,7 @@ set -ex pipefail
 
 export DEPLOY_CNAO=${DEPLOY_CNAO:-true}
 export DEPLOY_KUBEVIRT=${DEPLOY_KUBEVIRT:-true}
-export KUBEVIRT_PSA=${KUBEVIRT_PSA:-false}
+export KUBEVIRT_PSA=${KUBEVIRT_PSA:-true}
 
 source ./cluster/cluster.sh
 

--- a/hack/psa/kubevirt.yaml
+++ b/hack/psa/kubevirt.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - KubevirtSeccompProfile
+    seccompConfiguration:
+      virtualMachineInstanceProfile:
+        customProfile:
+          localhostProfile: kubevirt/kubevirt.json


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
To be able to run VMs on a namespace with restricted PSA policy, KubevirtSeccompProfile feature gate should be enabled and a new configuration needs to be enabled under
.spec.configuration.seccompConfiguration

```
virtualMachineInstanceProfile:
   customProfile:
       localhostProfile: kubevirt/kubevirt.json
```

Reference: https://github.com/kubevirt/kubevirt/pull/8917

**Special notes for your reviewer**:
