### PR TITLE
coreDNS: Bump version

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -84,7 +84,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: registry.k8s.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.10.1
         imagePullPolicy: IfNotPresent
         name: secondary-dns
         securityContext:


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we moved from k8s.gcr.io to registry.k8s.io
the current version is aliased in those two.
This cause CNAO update test to fail because it expects the new URL 
but the image is detected as the previous one.
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/1552/pull-e2e-cluster-network-addons-operator-lifecycle-k8s/1659558012878065664

Having a new image will solve this, and it should be fine to update the version every now and then.

**Special notes for your reviewer**:
