### PR TITLE
Fix NS line for the zone file

### DIFF
--- a/pkg/zonemgr/internal/zone-file-cache/zone_file_cache.go
+++ b/pkg/zonemgr/internal/zone-file-cache/zone_file_cache.go
@@ -76,7 +76,7 @@ func (zoneFileCache *ZoneFileCache) generateHeaderSuffix() {
 	zoneFileCache.headerSuf = fmt.Sprintf(" %s %s %s %s)\n", refresh, retry, expire, ttl)
 
 	if zoneFileCache.nameServerIP != "" {
-		zoneFileCache.headerSuf += fmt.Sprintf("IN NS %s.\n", zoneFileCache.nameServerName)
+		zoneFileCache.headerSuf += fmt.Sprintf("@ IN NS %s.\n", zoneFileCache.nameServerName)
 		zoneFileCache.headerSuf += fmt.Sprintf("%s IN A %s\n", nameServerDefault, zoneFileCache.nameServerIP)
 	}
 }

--- a/pkg/zonemgr/internal/zone-file-cache/zone_file_cache_test.go
+++ b/pkg/zonemgr/internal/zone-file-cache/zone_file_cache_test.go
@@ -24,7 +24,7 @@ var _ = Describe("cached zone file content maintenance", func() {
 	Describe("cached zone file initialization", func() {
 		const (
 			headerDefault   = "$ORIGIN vm. \n$TTL 3600 \n@ IN SOA ns.vm. email.vm. (0 3600 3600 1209600 3600)\n"
-			headerCustomFmt = "$ORIGIN vm.%s. \n$TTL 3600 \n@ IN SOA ns.vm.%s. email.vm.%s. (0 3600 3600 1209600 3600)\nIN NS ns.vm.%s.\nns IN A %s\n"
+			headerCustomFmt = "$ORIGIN vm.%s. \n$TTL 3600 \n@ IN SOA ns.vm.%s. email.vm.%s. (0 3600 3600 1209600 3600)\n@ IN NS ns.vm.%s.\nns IN A %s\n"
 			headerSoaSerial = "$ORIGIN vm. \n$TTL 3600 \n@ IN SOA ns.vm. email.vm. (12345 3600 3600 1209600 3600)\n"
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a missing `@` at the beginning of the NS record, which caused the line to be invalid, and we didn't get any alerts about it on zone re/load. 

This also broke recourse query for the NS, as the query will be passed to the internal DNS, but the record is missing.


**Special notes for your reviewer**:

When asking the parent (forcing no recursive query) DNS for the NS, we get a response, 

```
❯ dig NS vm.cnv2.example.com @ns1.eng.example.com +norecurse

; <<>> DiG 9.18.17 <<>> NS vm.cnv2.example.com @ns1.eng.example.com +norecurse
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 32195
;; flags: qr ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 2

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;vm.cnv2.example.com.        IN      NS

;; AUTHORITY SECTION:
vm.cnv2.example.com. 300 IN  NS      ns.vm.cnv2.example.com.

;; ADDITIONAL SECTION:
ns.vm.cnv2.example.com. 300 IN A     10.46.41.90

;; Query time: 9 msec
;; SERVER: 10.46.0.31#53(ns1.eng.example.com) (UDP)
;; WHEN: Thu Sep 14 16:10:56 IDT 2023
;; MSG SIZE  rcvd: 92
```

But when the server redirects us to our internal DNS, we get not respond.

```
❯ dig NS vm.cnv2.example.com @ns1.eng.example.com

; <<>> DiG 9.18.17 <<>> NS vm.cnv2.example.com @ns1.eng.example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 21606
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;vm.cnv2.example.com.        IN      NS

;; Query time: 24 msec
;; SERVER: 10.46.0.31#53(ns1.eng.example.com) (UDP)
;; WHEN: Thu Sep 14 16:11:04 IDT 2023
;; MSG SIZE  rcvd: 59
```

I tested this by manually patching the zone file to include the missing `@`.