### PR TITLE
kubevirtci: Bump kubevirtci

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -14,7 +14,7 @@
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
 export KUBEVIRT_NUM_NODES=1
-export KUBEVIRTCI_TAG='2212161203-bcbedfe'
+export KUBEVIRTCI_TAG='2306031446-398ee73'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:
Latest (`2309141019-029e67a`) kubevirtci doesn't work [1]
for now pinning newer than current meanwhile,

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubesecondarydns/62/pull-kubesecondarydns-e2e-k8s/1703684178278617088