### PR TITLE
ci: Enable building for s390x and arm64

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Container Registry
         if: github.repository_owner == 'kubevirt'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Push latest container image
         if: github.repository_owner == 'kubevirt'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/s390x
@@ -50,7 +50,7 @@ jobs:
 
       - name: Push tagged container image
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/s390x
@@ -65,7 +65,7 @@ jobs:
         run: IMAGE=ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }} hack/update-manifest.sh
 
       - name: Release the kraken
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64,linux/s390x,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:latest
           file: Dockerfile
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64,linux/s390x,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }}
           file: Dockerfile

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -8,8 +8,8 @@ on:
 env:
   image-push-owner: 'kubevirt'
 jobs:
-  push-amd64:
-    name: Image push/amd64
+  push:
+    name: Image push
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -41,6 +41,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/s390x
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:latest
           file: Dockerfile
@@ -52,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/s390x
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{  github.ref_name }}
           file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -13,8 +13,10 @@ RUN go mod download
 COPY main.go main.go
 COPY pkg/ pkg/
 
+ARG TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.19 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -2,7 +2,26 @@
 
 destination=$1
 version=$(grep "^go " go.mod |awk '{print $2}')
-tarball=go$version.linux-amd64.tar.gz
+
+arch="$(uname -m)"
+
+case $arch in
+    x86_64 | amd64)
+        arch="amd64"
+        ;;
+    aarch64 | arm64)
+        arch="arm64"
+        ;;
+    s390x)
+        arch="s390x"
+        ;;
+    *)
+        echo "ERROR: invalid arch=${arch}, only support x86_64, aarch64 and s390x"
+        exit 1
+        ;;
+esac
+
+tarball=go$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/
 
 mkdir -p $destination


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
This PR enables building kubesecondarydns for s390x in addition to amd64.
Additionally arm64 is enabled as well, though i can't test it to verify it works.
Additionally it bumps the workflow action versions to their latest to get rid of multiple deprecation warnings.
Finally it fixes a small warning about the case of "AS" in the Dockerfile.

**Special notes for your reviewer**:
PRs to enable unit-tests and build test for s390x will follow. E2E needs the provider, which for s390x still has some problems to be worked out.