### PR TITLE
install-go.sh: Support installing golang on multiple arches

### DIFF
--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -2,7 +2,26 @@
 
 destination=$1
 version=$(grep "^go " go.mod |awk '{print $2}')
-tarball=go$version.linux-amd64.tar.gz
+
+arch="$(uname -m)"
+
+case $arch in
+    x86_64 | amd64)
+        arch="amd64"
+        ;;
+    aarch64 | arm64)
+        arch="arm64"
+        ;;
+    s390x)
+        arch="s390x"
+        ;;
+    *)
+        echo "ERROR: invalid arch=${arch}, only support x86_64, aarch64 and s390x"
+        exit 1
+        ;;
+esac
+
+tarball=go$version.linux-$arch.tar.gz
 url=https://dl.google.com/go/
 
 mkdir -p $destination


### PR DESCRIPTION
Add support for installing golang on arm64 and s390x.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
Support running go dependent make command on multiple arches by allowing go to be installed on amd64, aarch64 and s390x.

**Special notes for your reviewer**:
This enables running unit-tests on s390x.