### PR TITLE
e2e: Change containerdisk from cirros to alpine

### DIFF
--- a/tests/vm_generator.go
+++ b/tests/vm_generator.go
@@ -83,7 +83,7 @@ func addNoCloudDiskWitUserData(spec *v1.VirtualMachineInstanceSpec, data string)
 func CreateVmiObject(name string, namespace string, interfaces []v1.Interface, networks []v1.Network) *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(randName(name))
 	vmi.Namespace = namespace
-	addContainerDisk(&vmi.Spec, "quay.io/kubevirt/cirros-container-disk-demo:devel")
+	addContainerDisk(&vmi.Spec, "quay.io/kubevirt/alpine-container-disk-demo:v1.4.0")
 	addNoCloudDiskWitUserData(&vmi.Spec, "#!/bin/sh\n\necho 'printed from cloud-init userdata'\n")
 	vmi.Spec.Domain.Devices.Interfaces = interfaces
 	vmi.Spec.Networks = networks


### PR DESCRIPTION
The cirros image is not supported on s390x, use alpine instead.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
Cirros is not built for s390x. Changing it to alpine ensures the e2e test can be run on s390x.

**Special notes for your reviewer**:
