### PR TITLE
Disable CGO when running unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(GO):
 
 # Run unit tests
 test: $(GO)
-	$(GO) test ./pkg/... -coverprofile cover.out
+	CGO_ENABLED=0 $(GO) test ./pkg/... -coverprofile cover.out
 
 # Run e2e tests
 functest: $(GO)


### PR DESCRIPTION
When running unit-tests, go tries to compile using CGO, despite not needing it. This can lead to errors on systems not having gcc installed, or named wrongly.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
Disable CGO for running unit-tests

**Special notes for your reviewer**:
