### PR TITLE
Dockerfile: Fix wrong base image arch when cross-building with podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG TARGETARCH
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/manager .
 


### PR DESCRIPTION
When cross-building the image for s390x on amd64, podman would use an amd64 image for the base of the final image.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

-->

**What this PR does / why we need it**:
Fix cross-building manually on amd64 with podman.

**Special notes for your reviewer**:
