### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -106,6 +106,7 @@ spec:
         - name: secdns-zones
           mountPath: /zones
           readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: status-monitor
         securityContext:
           allowPrivilegeEscalation: false
@@ -130,6 +131,7 @@ spec:
               configMapKeyRef:
                 name: secondary-dns
                 key: NAME_SERVER_IP
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:
