### PR TITLE
Add Network policies

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -27,6 +27,9 @@ make push
 make cluster-clean
 make deploy
 
+# Ensure the project network-polices are valid by simulating network restrictions using network-policy
+./hack/install-network-policy.sh
+
 pods_ready_wait() {
   if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
     echo "Waiting for non secondary-dns containers to be ready ..."

--- a/hack/install-network-policy.sh
+++ b/hack/install-network-policy.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -ex
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script simulating network restriction by installing deny-all NetworkPolicy in the project namespace.
+# Since allowing access for cluster API and DNS is fundamental requirement for the project, an appropriate NetworkPolicies are installed.
+
+readonly ns="$(./cluster/kubectl.sh get pod -l k8s-app=secondary-dns -A -o=custom-columns=NS:.metadata.namespace --no-headers | head -1)"
+[[ -z "${ns}" ]] && echo "FATAL: kube-secondary-dns pods not found. Make sure kube-secondary-dns is installed" && exit 1
+
+cat <<EOF | ./cluster/kubectl.sh -n "${ns}" apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-cluster-dns
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: secondary-dns
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: TCP
+      port: dns-tcp
+    - protocol: UDP
+      port: dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-cluster-api
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: secondary-dns
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+EOF

--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -181,3 +181,19 @@ spec:
           name: secondary-dns
       - name: secdns-zones
         emptyDir: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-secondary-dns
+  namespace: secondary
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: secondary-dns
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: UDP
+      port: dns


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Introduce permissive network policies for the project allowing it to coplicy with network restrictions, in form of a global deny-all network policy.

This PR add permissive network-policy allowing ingress to the secondary DNS instance service.

**Special notes for your reviewer**:
In order to have test coverage, a deny-all network-policy is installed as part of the cluster-sync flow.
Having it installed as part of the cluster-sync flow ensure coverage for dev and tests envs, locally and on CI.
In addition to the deny-all NP, a permissive policy allowing access to cluster API and DNS is installed, as it is fundamental requirement for any k8s controller:
- Allow egress to cluster DNS
  Enable interaction with cluster DNS, w/o this policy the
  KSD manager cannot establish connection with the cluster API.
- Allow egress to kube-apiserver
  Enable interaction with the cluster API, w/o this policy the manager
  cannot r/w VMs/Pods, and the cert-manager cannot rotate certificates.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
manifests: Introduce network-policies to enable KSD operate in restricted env
```
