### PR TITLE
probes: Use different port for coredns ready

### DIFF
--- a/manifests/secondarydns.yaml
+++ b/manifests/secondarydns.yaml
@@ -17,7 +17,7 @@ data:
         reload
         log
         health :8082
-        ready :8082
+        ready :8083
     }
 kind: ConfigMap
 metadata:
@@ -100,6 +100,9 @@ spec:
         - containerPort: 8082
           name: healthport
           protocol: TCP
+        - containerPort: 8083
+          name: readyport
+          protocol: TCP
         resources:
           requests:
             cpu: 100m
@@ -115,7 +118,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /ready
-            port: healthport
+            port: readyport
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the coredns health and ready plugins they should use different port or unexpected things happends.

The default ports for ready and health plugins are already different 8081 vs 8080
https://github.com/coredns/coredns/tree/master/plugin/ready
https://github.com/coredns/coredns/tree/master/plugin/health